### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/102/026/317/102026317.geojson
+++ b/data/102/026/317/102026317.geojson
@@ -54,6 +54,9 @@
         "qs_pg:id":356107
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5d63c2ce96f2cc885fbf05f58c18aeaf",
     "wof:hierarchy":[
         {
@@ -65,7 +68,7 @@
         }
     ],
     "wof:id":102026317,
-    "wof:lastmodified":1566581626,
+    "wof:lastmodified":1582347114,
     "wof:name":"Taisen-ri",
     "wof:parent_id":890472595,
     "wof:placetype":"locality",

--- a/data/102/026/381/102026381.geojson
+++ b/data/102/026/381/102026381.geojson
@@ -317,6 +317,9 @@
         "wd:id":"Q42094"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"36d814c78cffefb148d69bb75ad595f8",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
         }
     ],
     "wof:id":102026381,
-    "wof:lastmodified":1566581626,
+    "wof:lastmodified":1582347114,
     "wof:name":"Moppo",
     "wof:parent_id":890474687,
     "wof:placetype":"locality",

--- a/data/858/982/27/85898227.geojson
+++ b/data/858/982/27/85898227.geojson
@@ -111,6 +111,11 @@
         "wk:page":"Banjica"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6547e027d314211535b084db55de183",
     "wof:hierarchy":[
         {
@@ -127,7 +132,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581686,
+    "wof:lastmodified":1582347124,
     "wof:name":"Banjica",
     "wof:parent_id":101913173,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/29/85898229.geojson
+++ b/data/858/982/29/85898229.geojson
@@ -142,6 +142,11 @@
         "wd:id":"Q341728"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9e0b095ee9fbd0078baf4fd746cbc65d",
     "wof:hierarchy":[
         {
@@ -158,7 +163,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581686,
+    "wof:lastmodified":1582347124,
     "wof:name":"\u010cukarica",
     "wof:parent_id":101914149,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/31/85898231.geojson
+++ b/data/858/982/31/85898231.geojson
@@ -127,6 +127,11 @@
         "wd:id":"Q2396145"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a256296674f35ec1f9d99c0c93d0d286",
     "wof:hierarchy":[
         {
@@ -143,7 +148,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581686,
+    "wof:lastmodified":1582347124,
     "wof:name":"Dor\u0107ol",
     "wof:parent_id":101914143,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/33/85898233.geojson
+++ b/data/858/982/33/85898233.geojson
@@ -80,6 +80,11 @@
         "qs_pg:id":343376
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"69a4d2cc89fda5365eb612cc3382b99b",
     "wof:hierarchy":[
         {
@@ -96,7 +101,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581686,
+    "wof:lastmodified":1582347124,
     "wof:name":"Du\u00b5anovac",
     "wof:parent_id":101913173,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/35/85898235.geojson
+++ b/data/858/982/35/85898235.geojson
@@ -72,6 +72,10 @@
         "gp:id":535648
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1cc1256f5f7716e57a9f52c052b95bd1",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581685,
+    "wof:lastmodified":1582347124,
     "wof:name":"Novi Beograd",
     "wof:parent_id":101914147,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/37/85898237.geojson
+++ b/data/858/982/37/85898237.geojson
@@ -94,6 +94,10 @@
         "wd:id":"Q3183106"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "mz"
+    ],
     "wof:geomhash":"e581a651eff408d8498fe7e53c1fdffa",
     "wof:hierarchy":[
         {
@@ -110,7 +114,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581686,
+    "wof:lastmodified":1582347124,
     "wof:name":"Senjak",
     "wof:parent_id":101914163,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/39/85898239.geojson
+++ b/data/858/982/39/85898239.geojson
@@ -110,6 +110,11 @@
         "wd:id":"Q655022"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1ba5d98eb7a0ca7b844830bbd6a7f571",
     "wof:hierarchy":[
         {
@@ -126,7 +131,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581686,
+    "wof:lastmodified":1582347124,
     "wof:name":"Top\u010didersko Brdo",
     "wof:parent_id":101913173,
     "wof:placetype":"neighbourhood",

--- a/data/858/982/43/85898243.geojson
+++ b/data/858/982/43/85898243.geojson
@@ -151,6 +151,11 @@
         "wd:id":"Q1006522"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "mz",
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"15bc7cc2ca308598f8ca8176b376a72c",
     "wof:hierarchy":[
         {
@@ -167,7 +172,7 @@
     "wof:lang":[
         "unk"
     ],
-    "wof:lastmodified":1566581686,
+    "wof:lastmodified":1582347124,
     "wof:name":"Vra\u010dar",
     "wof:parent_id":101914161,
     "wof:placetype":"neighbourhood",

--- a/data/859/252/89/85925289.geojson
+++ b/data/859/252/89/85925289.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":1197751
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"468d0e6122cba6750ed212771ae4c4a3",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581685,
+    "wof:lastmodified":1582347124,
     "wof:name":"\ud30c\uc7a5\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/252/93/85925293.geojson
+++ b/data/859/252/93/85925293.geojson
@@ -88,6 +88,10 @@
         "qs_pg:id":230181
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fe9518d3efa9e2b5ec41ee09ada77fa3",
     "wof:hierarchy":[
         {
@@ -103,7 +107,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581685,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc728\ucc9c\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/252/99/85925299.geojson
+++ b/data/859/252/99/85925299.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1293150
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"52f3e4afc81927dd330fab755855a534",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581685,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc815\uc7901\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/03/85925303.geojson
+++ b/data/859/253/03/85925303.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1293149
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e9470b6f41fb49ebec185cdc7ed4827f",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc815\uc7902\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/07/85925307.geojson
+++ b/data/859/253/07/85925307.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1091434
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d0867dc32c7fcec32e3baa3d13c50ba0",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581667,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc815\uc7903\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/11/85925311.geojson
+++ b/data/859/253/11/85925311.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1086451
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4a6b59ca180121415e6c674576b2e2f8",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581666,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc601\ud654\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/17/85925317.geojson
+++ b/data/859/253/17/85925317.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":204114
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"beec7450a50423c9e604be8481cce152",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581666,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc1a1\uc8fd\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/19/85925319.geojson
+++ b/data/859/253/19/85925319.geojson
@@ -87,6 +87,10 @@
         "wk:page":"Jowon-dong, Suwon"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"698da3511f7dcc0ab6693597a5ae95a4",
     "wof:hierarchy":[
         {
@@ -102,7 +106,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581666,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc870\uc6d02\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/23/85925323.geojson
+++ b/data/859/253/23/85925323.geojson
@@ -82,6 +82,10 @@
         "qs_pg:id":230183
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"83aabefb0ae4d519157232bf1ad78375",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581668,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc5f0\ubb34\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/27/85925327.geojson
+++ b/data/859/253/27/85925327.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":358461
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c5edc419b64e54049690ac11f71e9593",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc138\ub9581\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/33/85925333.geojson
+++ b/data/859/253/33/85925333.geojson
@@ -84,6 +84,10 @@
         "qs_pg:id":1293151
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"009c784f813ef410495088ccc5605b49",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc138\ub9582\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/35/85925335.geojson
+++ b/data/859/253/35/85925335.geojson
@@ -82,6 +82,10 @@
         "qs_pg:id":358462
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec9689f280cc1d0bccbeaf9400abebdb",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ud3c9\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/39/85925339.geojson
+++ b/data/859/253/39/85925339.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1293146
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3eff256f39ba23ef6fc73e2137a2649b",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581667,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc11c\ub454\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/43/85925343.geojson
+++ b/data/859/253/43/85925343.geojson
@@ -86,6 +86,10 @@
         "qs_pg:id":424402
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f587f8c9f73528e4b71c6f02cc94fc22",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581667,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ud314\ub2ec\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/47/85925347.geojson
+++ b/data/859/253/47/85925347.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":424404
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ec6fbb38f392efe6c38d22b75ed0699",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581668,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc2e0\uc548\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/51/85925351.geojson
+++ b/data/859/253/51/85925351.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":424406
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8ffe273311b19840dc33e3841c6fb598",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uace0\ub4f1\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/55/85925355.geojson
+++ b/data/859/253/55/85925355.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":216126
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"df9958c9e8dcc3201a3cb1bebbc55ebe",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581667,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ud654\uc11c1\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/59/85925359.geojson
+++ b/data/859/253/59/85925359.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":237080
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a3d60577cd48f493df00322136c4cfcb",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc9c0\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/63/85925363.geojson
+++ b/data/859/253/63/85925363.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1080160
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"061487038ac251a360be1828c72f1d50",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581667,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc6b0\ub9cc1\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/69/85925369.geojson
+++ b/data/859/253/69/85925369.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":905517
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"db9d0f962a33891d55420b0bc458f62a",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc778\uacc4\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/73/85925373.geojson
+++ b/data/859/253/73/85925373.geojson
@@ -83,6 +83,10 @@
         "qs_pg:id":70926
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"20b58da4bd3a7baebddf522e16409c3f",
     "wof:hierarchy":[
         {
@@ -98,7 +102,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581666,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ub9e4\ud0c42\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/77/85925377.geojson
+++ b/data/859/253/77/85925377.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1293159
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"661bb2ab650118a40ea508b2f0fc17f6",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581668,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ub9e4\ud0c43\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/81/85925381.geojson
+++ b/data/859/253/81/85925381.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1293160
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5843f5861b9f695d897c53b7a88978a7",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581667,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ub9e4\ud0c44\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/87/85925387.geojson
+++ b/data/859/253/87/85925387.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1293164
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"35bb5b412dea8d0a0dafd45ccb49c8a6",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581666,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc601\ud1b51\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/89/85925389.geojson
+++ b/data/859/253/89/85925389.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":1182419
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"02f5fa89813e6079069fd371a6404c7c",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581666,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc601\ud1b52\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/93/85925393.geojson
+++ b/data/859/253/93/85925393.geojson
@@ -77,6 +77,9 @@
         "gp:id":28806698
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b906b4d320b7f47dfc3f807603a92274",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc2e0\ud7652\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/253/97/85925397.geojson
+++ b/data/859/253/97/85925397.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1091437
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"300cd4949f5c02497b3093e6a693cc96",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581667,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ud0dc\ud3c91\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/01/85925401.geojson
+++ b/data/859/254/01/85925401.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":1182418
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ce4fa6936baafb78d55536b11a1bc33f",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ud0dc\ud3c94\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/07/85925407.geojson
+++ b/data/859/254/07/85925407.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":267136
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4e410cda63e584a3214f69e1b9b177c9",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ub2e8\ub300\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/15/85925415.geojson
+++ b/data/859/254/15/85925415.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1091436
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"91f390ec52b5f98ef700da82f736b5c0",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ubcf5\uc815\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/29/85925429.geojson
+++ b/data/859/254/29/85925429.geojson
@@ -85,6 +85,9 @@
         "wd:id":"Q2647715"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1442273083b45efae9539622d56b278c",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581668,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc2dc\ud765\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/37/85925437.geojson
+++ b/data/859/254/37/85925437.geojson
@@ -71,6 +71,9 @@
         "gp:id":28806715
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5ea2f59b3f311e12430fef3417e79065",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uae08\uad111\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/53/85925453.geojson
+++ b/data/859/254/53/85925453.geojson
@@ -86,6 +86,10 @@
         "qs_pg:id":1332437
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2ef8a76166a5a31872816a05ed413f3c",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc218\ub0b41\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/59/85925459.geojson
+++ b/data/859/254/59/85925459.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1250958
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2bdd911a3eb2d79876ad859c4e9903b2",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581668,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc815\uc7901\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/63/85925463.geojson
+++ b/data/859/254/63/85925463.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":281581
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"301404082aab38aa35eea8be7e46f249",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc815\uc7902\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/71/85925471.geojson
+++ b/data/859/254/71/85925471.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":985731
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6568223a07708bb3f74e08043cca67a9",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581670,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc11c\ud6042\ub3d9",
     "wof:parent_id":102026389,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/77/85925477.geojson
+++ b/data/859/254/77/85925477.geojson
@@ -82,6 +82,10 @@
         "wd:id":"Q6002022"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"06b5ace81749ca1ab17ec5253535eb45",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc774\ub9e41\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/81/85925481.geojson
+++ b/data/859/254/81/85925481.geojson
@@ -84,6 +84,10 @@
         "wd:id":"Q6002022"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"95249665f8c21f52ef9259fdd45f18a5",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581668,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc774\ub9e42\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/85/85925485.geojson
+++ b/data/859/254/85/85925485.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":281580
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4603cd521a7aecd57f6de119a2696a8b",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc57c\ud0d11\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/95/85925495.geojson
+++ b/data/859/254/95/85925495.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1086456
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e1308f40a2f728f4278350ff94064ed8",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581668,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ud310\uad50\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/254/99/85925499.geojson
+++ b/data/859/254/99/85925499.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q5554848"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9277316752db3ae09d83f31124b52a20",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581669,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uae08\uace11\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/03/85925503.geojson
+++ b/data/859/255/03/85925503.geojson
@@ -90,6 +90,10 @@
         "wk:page":"Geumgok-dong, Seongnam"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"163c29fbb32ee63c0f7262a2b2a2c250",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581683,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uae08\uace12\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/09/85925509.geojson
+++ b/data/859/255/09/85925509.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1128228
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a02579cef810871478756b9b4051ed65",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc548\uc5911\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/15/85925515.geojson
+++ b/data/859/255/15/85925515.geojson
@@ -82,6 +82,10 @@
         "qs_pg:id":1293193
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ee6dfa88c263fd49d4599953a42e0eb8",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc548\uc5912\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/19/85925519.geojson
+++ b/data/859/255/19/85925519.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1293190
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2b1d246177ba4a4cc774c2ad8464d7b",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc548\uc5913\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/23/85925523.geojson
+++ b/data/859/255/23/85925523.geojson
@@ -70,6 +70,9 @@
         "gp:id":28806758
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b258e1d85c8d9f0cef464802f6a12dad",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc548\uc5914\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/27/85925527.geojson
+++ b/data/859/255/27/85925527.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":358503
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c946880a5e299c50d1ce4095ca769381",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581683,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc548\uc5918\ub3d9",
     "wof:parent_id":102026401,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/33/85925533.geojson
+++ b/data/859/255/33/85925533.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1086457
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e7cf5657acc8b71c702cb89c74e9d664",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581683,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc11d\uc2181\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/37/85925537.geojson
+++ b/data/859/255/37/85925537.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":221575
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1fe295a4556d137ac64d5306f6ae34d2",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc11d\uc2182\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/41/85925541.geojson
+++ b/data/859/255/41/85925541.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1186085
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7a4fddcbecd5e0b8bbd1170f40d04ca4",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\ubc15\ub2ec2\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/45/85925545.geojson
+++ b/data/859/255/45/85925545.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":11401
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"87560768c94a95556d882e845df295f0",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581683,
+    "wof:lastmodified":1582347124,
     "wof:name":"\ube44\uc0b01\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/49/85925549.geojson
+++ b/data/859/255/49/85925549.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1186094
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f94a38166905427d2fdd69f1c63fb0b5",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581685,
+    "wof:lastmodified":1582347124,
     "wof:name":"\ube44\uc0b03\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/53/85925553.geojson
+++ b/data/859/255/53/85925553.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1197759
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d2239e3ce953b0d7bd3f75d47d87eef4",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\ub2ec\uc548\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/57/85925557.geojson
+++ b/data/859/255/57/85925557.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1197757
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6875ad488058c5cd12553fbfe0922f78",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581682,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uad00\uc5911\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/61/85925561.geojson
+++ b/data/859/255/61/85925561.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1186087
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fcc44aab9c69b64f7dcf75e590820f52",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581682,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uad00\uc5912\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/67/85925567.geojson
+++ b/data/859/255/67/85925567.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":241687
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a05e25ae768aad387c77331af96f211a",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581683,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ubd80\ub9bc\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/71/85925571.geojson
+++ b/data/859/255/71/85925571.geojson
@@ -66,6 +66,10 @@
         "wd:id":"Q14000007"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"728270d5bca0e300560ed77e68c7d9a7",
     "wof:hierarchy":[
         {
@@ -81,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581685,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uadc0\uc778\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/75/85925575.geojson
+++ b/data/859/255/75/85925575.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":772290
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"43628dd2fe933708ffd948442b81f1b5",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\ud638\uacc41\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/85/85925585.geojson
+++ b/data/859/255/85/85925585.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1197758
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cfc3fa57f13b772715009a9bde712435",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc2e0\ucd0c\ub3d9",
     "wof:parent_id":102026501,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/89/85925589.geojson
+++ b/data/859/255/89/85925589.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1293206
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ddf20cf2f97cc5f6547d7b2bb3fb0abe",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581683,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc2ec\uace13\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/93/85925593.geojson
+++ b/data/859/255/93/85925593.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1293200
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"af3708da70b765fa6733e57d30f47cc8",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581683,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc5ed\uace11\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/255/97/85925597.geojson
+++ b/data/859/255/97/85925597.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1293201
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd8ef43d3e3a9ce41bc5350fccd09cbf",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581684,
+    "wof:lastmodified":1582347124,
     "wof:name":"\uc911\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/03/85925603.geojson
+++ b/data/859/256/03/85925603.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":968960
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"aff64418a25dd1ae0a74ad72f82612d8",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc9113\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/07/85925607.geojson
+++ b/data/859/256/07/85925607.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":220927
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a83d339550939ddfa6f76cf7064a09e0",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc9114\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/11/85925611.geojson
+++ b/data/859/256/11/85925611.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1128230
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5f56fdbdf183731e842b288bbb9d315",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc0c1\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/15/85925615.geojson
+++ b/data/859/256/15/85925615.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1197760
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2a4013776b3a304e49221869f7d07a6",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581655,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc0c11\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/21/85925621.geojson
+++ b/data/859/256/21/85925621.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1091438
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa231c54f2c5d768ba5983e1e7d79d3f",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc0c12\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/25/85925625.geojson
+++ b/data/859/256/25/85925625.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":911192
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"91b851d598a996b69c70d117996ff7c6",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581655,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uad34\uc548\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/29/85925629.geojson
+++ b/data/859/256/29/85925629.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":1119022
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"976d080452bd700a917fa6e201fc9080",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc624\uc815\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/33/85925633.geojson
+++ b/data/859/256/33/85925633.geojson
@@ -64,6 +64,10 @@
         "wd:id":"Q12613630"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4a7c4834b13941e7cbf52607f44c02c1",
     "wof:hierarchy":[
         {
@@ -79,7 +83,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc77c\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/39/85925639.geojson
+++ b/data/859/256/39/85925639.geojson
@@ -98,6 +98,10 @@
         "wd:id":"Q12613630"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3aefe15213a2ba37e7577eab290607ef",
     "wof:hierarchy":[
         {
@@ -113,7 +117,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc774\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/43/85925643.geojson
+++ b/data/859/256/43/85925643.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1287102
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"649600c7e57ab5f773b4e3fb6c39e50d",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc0ac1\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/51/85925651.geojson
+++ b/data/859/256/51/85925651.geojson
@@ -62,6 +62,10 @@
         "wd:id":"Q12598677"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a1ee7e6c490f78db7f0a11f5fa883974",
     "wof:hierarchy":[
         {
@@ -77,7 +81,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ubd80\uace1\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/57/85925657.geojson
+++ b/data/859/256/57/85925657.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1197749
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1dcfc5f190039455cda3ca20c650a4ba",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc6d4\ud53c\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/61/85925661.geojson
+++ b/data/859/256/61/85925661.geojson
@@ -61,6 +61,10 @@
         "wd:id":"Q12602147"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ddc9d7b6a474c2e39c1e5d2312fe3707",
     "wof:hierarchy":[
         {
@@ -76,7 +80,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc131\ud3ec\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/63/85925663.geojson
+++ b/data/859/256/63/85925663.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q16169313"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b13ccc35e04f17513044d6519a97f40a",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc548\uc0b0\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/67/85925667.geojson
+++ b/data/859/256/67/85925667.geojson
@@ -89,6 +89,10 @@
         "qs_pg:id":483971
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"49dcaa1497126fbf4f757041ec8e58b4",
     "wof:hierarchy":[
         {
@@ -104,7 +108,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uace0\uc7941\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/71/85925671.geojson
+++ b/data/859/256/71/85925671.geojson
@@ -59,6 +59,9 @@
         "wd:id":"Q12625251"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d4e109a7298316347ac437873a55bbe1",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581655,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ud638\uc218\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/77/85925677.geojson
+++ b/data/859/256/77/85925677.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":991025
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"495da9008659f082aa0e0eb33009e5e3",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581655,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc6d0\uace12\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/81/85925681.geojson
+++ b/data/859/256/81/85925681.geojson
@@ -82,6 +82,10 @@
         "qs_pg:id":772291
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aea1aabea2f0b9c6d01db3d8d97d4b9d",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc120\ubd801\ub3d9",
     "wof:parent_id":102026505,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/95/85925695.geojson
+++ b/data/859/256/95/85925695.geojson
@@ -77,6 +77,9 @@
         "qs_pg:id":1197781
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c4e1bf1e70ec8870d2e1cd02f49a0b8",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ud6a8\uc790\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/99/85925699.geojson
+++ b/data/859/256/99/85925699.geojson
@@ -80,6 +80,10 @@
         "wd:id":"Q2647436"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96e782c65fdd1a7116fa4d2576099225",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581654,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ucc3d\ub989\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/07/85925707.geojson
+++ b/data/859/257/07/85925707.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":210219
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7a64c2192439011f57a371b5d29a2ad3",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uad00\uc0b0\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/17/85925717.geojson
+++ b/data/859/257/17/85925717.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":959161
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52ab8f524caebc2989ab13a0552cfd25",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud654\uc8151\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/19/85925719.geojson
+++ b/data/859/257/19/85925719.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":483983
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e748748a498bf37d62657d7c85a71f0b",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud589\uc8fc\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/23/85925723.geojson
+++ b/data/859/257/23/85925723.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":488673
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3a3fa4bf11686b4e4a6c23fcffbf5169",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581636,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud589\uc2e02\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/29/85925729.geojson
+++ b/data/859/257/29/85925729.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":483984
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"002b9263942e2fdf15901eae6cb057be",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud654\uc804\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/33/85925733.geojson
+++ b/data/859/257/33/85925733.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":985732
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ceb2f65d73bc13a79ffe3cf2a9647c1",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ub300\ub355\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/37/85925737.geojson
+++ b/data/859/257/37/85925737.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":911196
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf0e0a3d28cca2978077c8717bd92d52",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc2dd\uc0ac\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/41/85925741.geojson
+++ b/data/859/257/41/85925741.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":11414
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"686ec434c75e6f80e51d75a8fa229ee0",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc815\ubc1c\uc0b0\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/47/85925747.geojson
+++ b/data/859/257/47/85925747.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":358526
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3deeb82b4e341e77bd17aacde11ed3ae",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581636,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud48d\uc0b0\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/51/85925751.geojson
+++ b/data/859/257/51/85925751.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":11415
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bb7b5600fe691a59899838997b348612",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ub9c8\ub4502\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/55/85925755.geojson
+++ b/data/859/257/55/85925755.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1293290
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"456deb5289af571f78972801ce061f29",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc7a5\ud56d2\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/65/85925765.geojson
+++ b/data/859/257/65/85925765.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1293288
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bd7d97efba36adff4aa726dac64c671e",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc77c\uc0b01\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/69/85925769.geojson
+++ b/data/859/257/69/85925769.geojson
@@ -72,6 +72,10 @@
         "wd:id":"Q2648251"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7091a338048f0c02d97fbd136e580766",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud0c4\ud604\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/73/85925773.geojson
+++ b/data/859/257/73/85925773.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":893762
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d5e772ae6552127654b8f6468978ab91",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc8fc\uc5fd1\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/77/85925777.geojson
+++ b/data/859/257/77/85925777.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":893763
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f80d7acd999ad1ee3fa34e91219a905",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc8fc\uc5fd2\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/257/83/85925783.geojson
+++ b/data/859/257/83/85925783.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":1086461
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"39418a59febc9d94a3966ad86930bf72",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581635,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ub300\ud654\ub3d9",
     "wof:parent_id":102026411,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/13/85925813.geojson
+++ b/data/859/258/13/85925813.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":246017
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c67fc128301726818f6d3d1de71b0fa8",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc2e0\uac08\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/19/85925819.geojson
+++ b/data/859/258/19/85925819.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1293358
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9c538fe1cf18bb19682e54665b43f6d7",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uad6c\uac08\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/25/85925825.geojson
+++ b/data/859/258/25/85925825.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1293360
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"44d7aed448a7ffbb4c8974e3f54b4fcd",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581653,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc11c\ub18d\ub3d9",
     "wof:parent_id":102026453,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/33/85925833.geojson
+++ b/data/859/258/33/85925833.geojson
@@ -72,6 +72,9 @@
         "qs_pg:id":1001193
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3a37cfb4c247bbd5857c956368a70775",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ub9c8\ubd81\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/43/85925843.geojson
+++ b/data/859/258/43/85925843.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1197831
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8da75220d14e54159f63aa2acf3f4894",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ubcf4\uc815\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/47/85925847.geojson
+++ b/data/859/258/47/85925847.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":1293359
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1eeb7a6230ddceee0dda61e75fca74d7",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ud48d\ub355\ucc9c1\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/51/85925851.geojson
+++ b/data/859/258/51/85925851.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":182714
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e391d0826f3ff3be548ae43fb53ab925",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ud48d\ub355\ucc9c2\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/65/85925865.geojson
+++ b/data/859/258/65/85925865.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1154959
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"febac9e9d3ed9a3594a37c5a47130b76",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc8fd\uc8042\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/75/85925875.geojson
+++ b/data/859/258/75/85925875.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1197832
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"68fb1ab98354f4819316fb38af70eba9",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc0c1\ud6041\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/79/85925879.geojson
+++ b/data/859/258/79/85925879.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1154965
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"646874bec75a406fbd36959d5e163675",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc0c1\ud6042\ub3d9",
     "wof:parent_id":102026323,
     "wof:placetype":"neighbourhood",

--- a/data/859/258/83/85925883.geojson
+++ b/data/859/258/83/85925883.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":985734
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ba02c748840640eb0e850cddca6de40",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581652,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc131\ubcf5\ub3d9",
     "wof:parent_id":102026263,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/09/85925909.geojson
+++ b/data/859/259/09/85925909.geojson
@@ -91,6 +91,9 @@
         "wk:page":"Carwitzer See"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"20efdae542109f8fcf24567f99f71e7d",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581643,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc911\uc559\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/13/85925913.geojson
+++ b/data/859/259/13/85925913.geojson
@@ -178,6 +178,10 @@
         "wk:page":"Lachapelle-aux-Pots"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bfad5979a919ff71450d61fc04982d80",
     "wof:hierarchy":[
         {
@@ -193,7 +197,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581644,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ud48d\ub0a8\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/17/85925917.geojson
+++ b/data/859/259/17/85925917.geojson
@@ -82,6 +82,10 @@
         "qs_pg:id":224140
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f52ee3bb21a35f3589e9db0aa79c4a93",
     "wof:hierarchy":[
         {
@@ -97,7 +101,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581643,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub178\uc1a1\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/21/85925921.geojson
+++ b/data/859/259/21/85925921.geojson
@@ -104,6 +104,10 @@
         "wk:page":"Bezledy"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6c5283708acc77ad9f67bd02ddc97734",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581643,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc911\ud654\uc0b02\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/27/85925927.geojson
+++ b/data/859/259/27/85925927.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":992965
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ac61716e39f52066929bd79da0da94b2",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581643,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ud6a8\uc7904\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/31/85925931.geojson
+++ b/data/859/259/31/85925931.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1287415
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8057132946cfcd0845463a0b7fb1aa63",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581643,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc9c4\ubd812\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/35/85925935.geojson
+++ b/data/859/259/35/85925935.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":426144
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ece2a0fcb3e22429d3b27be22bb9db67",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub355\uc9c4\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/39/85925939.geojson
+++ b/data/859/259/39/85925939.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":426143
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"696bf92747ed0abd7083ab213023c2b1",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581644,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uae08\uc5541\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/45/85925945.geojson
+++ b/data/859/259/45/85925945.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":250252
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"50239b4aeff806f12ccd6c00adf6873f",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581643,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uae08\uc5542\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/49/85925949.geojson
+++ b/data/859/259/49/85925949.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1115419
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"70582168748807cc9ef6b3b59d2fd696",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581644,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc6b0\uc5441\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/53/85925953.geojson
+++ b/data/859/259/53/85925953.geojson
@@ -91,6 +91,10 @@
         "wk:page":"Hida-Hosoe Station"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9b062ded3e78bae63d2680ef0e4445e1",
     "wof:hierarchy":[
         {
@@ -106,7 +110,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581643,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc1a1\ucc9c1\ub3d9",
     "wof:parent_id":102026471,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/63/85925963.geojson
+++ b/data/859/259/63/85925963.geojson
@@ -98,6 +98,9 @@
         "qs_pg:id":1086467
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"98f2672ecf5dc5617bde8521ec18a975",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581644,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc11c\ube59\uace0",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/259/81/85925981.geojson
+++ b/data/859/259/81/85925981.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1062517
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"838482f44b4d9e9e2c20aa1fb5a60941",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581643,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub2e4\uc0ac\uc74d",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/53/85926053.geojson
+++ b/data/859/260/53/85926053.geojson
@@ -77,6 +77,9 @@
         "wd:id":"Q5647890"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c4d8c3024cca31cc3740d0dbadbfc8b0",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581648,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ud55c\uac15\ub85c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/57/85926057.geojson
+++ b/data/859/260/57/85926057.geojson
@@ -76,6 +76,9 @@
         "qs_pg:id":239283
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af8bdc73bb9958d08739559f2e856163",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581647,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc774\ucd0c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/61/85926061.geojson
+++ b/data/859/260/61/85926061.geojson
@@ -77,6 +77,9 @@
         "qs_pg:id":906297
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"853b88d80bfece1e8897838f6a721ff1",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581647,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc774\ud0dc\uc6d0\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/65/85926065.geojson
+++ b/data/859/260/65/85926065.geojson
@@ -93,6 +93,9 @@
         "wd:id":"Q5649011"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aaad9f89a3722dd51cf0e767f3dffcf2",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581648,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ud55c\ub0a8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/71/85926071.geojson
+++ b/data/859/260/71/85926071.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1091443
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9b3e44d3a8e78bdf62c1c336634eb3a0",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581649,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc655\uc2ed\ub9ac",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/83/85926083.geojson
+++ b/data/859/260/83/85926083.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":223748
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0ab439d813aec28bfdb7f8ff29f36f31",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581649,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ub178\uc720\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/260/93/85926093.geojson
+++ b/data/859/260/93/85926093.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1091444
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ede71b919c995d137bc32784fb323d5e",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581647,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uccad\ub7c9\ub9ac",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/261/01/85926101.geojson
+++ b/data/859/261/01/85926101.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":11425
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b25b4c40f09dcd62ee34f3fbf39a6a76",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581646,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc0c1\ubd09\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/261/07/85926107.geojson
+++ b/data/859/261/07/85926107.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":11428
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0439ff84be11795ae627cf3081598e38",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581645,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc911\ud654\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/261/21/85926121.geojson
+++ b/data/859/261/21/85926121.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":1091445
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2dc6cc50847324478c4bd28fcaeb1408",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581645,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc815\ub989\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/261/45/85926145.geojson
+++ b/data/859/261/45/85926145.geojson
@@ -79,6 +79,9 @@
         "wd:id":"Q2647535"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbcef1a49d8e961fb96588dc90f6047b",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581645,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ubbf8\uc544\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/261/63/85926163.geojson
+++ b/data/859/261/63/85926163.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":1085055
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"083fe72970533add26c6d8071e6e62cb",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581646,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ub3c4\ubd09\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/262/11/85926211.geojson
+++ b/data/859/262/11/85926211.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1154963
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c165e5ee2c73d1e78b81c201fc84a703",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581671,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ub0a8\uac00\uc88c",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/262/17/85926217.geojson
+++ b/data/859/262/17/85926217.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":236628
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f072b167c324880d7ffe0c481a765ae3",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581671,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ubd81\uac00\uc88c",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/262/35/85926235.geojson
+++ b/data/859/262/35/85926235.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":204122
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0528b6fa112103d05a9bcc6d43d4e47a",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581670,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc2e0\uc6d4\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/262/41/85926241.geojson
+++ b/data/859/262/41/85926241.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":236629
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"05116ad20cf008418ffe94df33d2fb52",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581673,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ub4f1\ucd0c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/262/69/85926269.geojson
+++ b/data/859/262/69/85926269.geojson
@@ -69,6 +69,9 @@
         "wd:id":"Q2648238"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3258ba49709c45e3ae13b2ad7885c38d",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581670,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uac00\ub9ac\ubd09\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/262/95/85926295.geojson
+++ b/data/859/262/95/85926295.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":427087
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e1651099642753669dc173c1e543f100",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581670,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc601\ub4f1\ud3ec",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/05/85926305.geojson
+++ b/data/859/263/05/85926305.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":32345
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"040a8c0ffc2ab3c0733b760692cc2fee",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581679,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ub3c4\ub9bc\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/13/85926313.geojson
+++ b/data/859/263/13/85926313.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":32250
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e1bc6d79b4a6b9a0084e76eafbebdd8b",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581682,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ub300\ub9bc\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/19/85926319.geojson
+++ b/data/859/263/19/85926319.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1068125
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af6b0cd359b50854a60914075320926a",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581680,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc0ac\ub2f9\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/25/85926325.geojson
+++ b/data/859/263/25/85926325.geojson
@@ -77,6 +77,9 @@
         "qs_pg:id":1086469
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7e48f10b62b09c437e16bfb895337750",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581682,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc2e0\ub300\ubc29\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/27/85926327.geojson
+++ b/data/859/263/27/85926327.geojson
@@ -70,6 +70,9 @@
         "wd:id":"Q2648219"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5dbb38d9811c8a2eafd7444aef655462",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581679,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ubd09\ucc9c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/35/85926335.geojson
+++ b/data/859/263/35/85926335.geojson
@@ -82,6 +82,9 @@
         "wd:id":"Q2681380"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"887f1937faaf7367db42b845c536a3f4",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581679,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc11c\ucd08\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/59/85926359.geojson
+++ b/data/859/263/59/85926359.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1086471
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff2f860dddc5790f623c5274ec851648",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581679,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ub300\uce58\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/63/85926363.geojson
+++ b/data/859/263/63/85926363.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1086472
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff874c3dffe71d690b92804958ea4303",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581681,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ub3c4\uace1\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/65/85926365.geojson
+++ b/data/859/263/65/85926365.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1222810
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bfafe84f04cb6e7af34a7091ec837151",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581681,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uac1c\ud3ec\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/73/85926373.geojson
+++ b/data/859/263/73/85926373.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":1086473
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"925e70f0eae12c59b6872cdbd9c08025",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581679,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ud48d\ub0a9\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/79/85926379.geojson
+++ b/data/859/263/79/85926379.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":11429
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"45f899b0cc0fc3c0f40eb002b19c95ae",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581681,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ub9c8\ucc9c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/83/85926383.geojson
+++ b/data/859/263/83/85926383.geojson
@@ -70,6 +70,9 @@
         "wd:id":"Q4855165"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a0963387102bc225b53e782f5b0e8ec2",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581682,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ubc29\uc774\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/263/87/85926387.geojson
+++ b/data/859/263/87/85926387.geojson
@@ -74,6 +74,9 @@
         "qs_pg:id":11426
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7cb629331e9843e5a662ea03a4e69b9e",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581679,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc1a1\ud30c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/15/85926415.geojson
+++ b/data/859/264/15/85926415.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Amsa-dong"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"73f83ff4d42f19d6be2b0ca5a19a2119",
     "wof:hierarchy":[
         {
@@ -98,7 +101,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581678,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc554\uc0ac\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/25/85926425.geojson
+++ b/data/859/264/25/85926425.geojson
@@ -75,6 +75,9 @@
         "wd:id":"Q2647734"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2151bafba025d464292fb40f654a492",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581678,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uae38\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/35/85926435.geojson
+++ b/data/859/264/35/85926435.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835169
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6f31f81a36022214710fc0946b6551c0",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581676,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc601\uc8fc\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/39/85926439.geojson
+++ b/data/859/264/39/85926439.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":224150
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3bbe313f2ca17fb549bb0b2dbb5d0022",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581678,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ub3d9\ub300\uc2e0\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/43/85926443.geojson
+++ b/data/859/264/43/85926443.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1294606
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c99ecdeef6456cbb2c195a71020c8cb9",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581677,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc11c\ub300\uc2e0\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/49/85926449.geojson
+++ b/data/859/264/49/85926449.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":427089
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d690c3000aada899d963adb94342e148",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581678,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ub0a8\ubd80\ubbfc\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/53/85926453.geojson
+++ b/data/859/264/53/85926453.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":224151
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e97d1b13b5d6a689f6d1222a18707cd4",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581678,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ucd08\ub7c9\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/57/85926457.geojson
+++ b/data/859/264/57/85926457.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835174
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa2b6897fa5e9acbb93df86e182ef1ef",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581676,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc218\uc815\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/61/85926461.geojson
+++ b/data/859/264/61/85926461.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":968063
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"194a0b1bbe646855a6e96fe04db3b0ce",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581676,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc88c\ucc9c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/67/85926467.geojson
+++ b/data/859/264/67/85926467.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1294614
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"451a7337bd8f5e26e8cf2255547ac31f",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581676,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ubc94\uc77c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/75/85926475.geojson
+++ b/data/859/264/75/85926475.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":232438
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"24635db8055ca9bf9092a9559e3237af",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581677,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ubd09\ub798\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/79/85926479.geojson
+++ b/data/859/264/79/85926479.geojson
@@ -63,6 +63,10 @@
         "qs_pg:id":427099
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d9413c5bf1b08a6b5484adb4969481d4",
     "wof:hierarchy":[
         {
@@ -77,7 +81,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581678,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uccad\ud559\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/87/85926487.geojson
+++ b/data/859/264/87/85926487.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":218184
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f9c08e6c0e7a1bacf89803a431494ada",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581677,
+    "wof:lastmodified":1582347123,
     "wof:name":"\ubd80\uc804\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/91/85926491.geojson
+++ b/data/859/264/91/85926491.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":218185
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4422e9fcd913b4856e912146a3c17467",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581677,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc804\ud3ec\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/264/99/85926499.geojson
+++ b/data/859/264/99/85926499.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835187
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85ec6b1313e465791158b34160e195d4",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581678,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uac00\uc57c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/05/85926505.geojson
+++ b/data/859/265/05/85926505.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":427100
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"586cc439d281a690c19025f8aa4c9fb3",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581674,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uac1c\uae08\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/09/85926509.geojson
+++ b/data/859/265/09/85926509.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":218186
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"b084e92255711750d699b83ce13791fa",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uba85\ub95c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/13/85926513.geojson
+++ b/data/859/265/13/85926513.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":895855
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ff2daf58adc4476c7863b322fec66d59",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581676,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc628\ucc9c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/17/85926517.geojson
+++ b/data/859/265/17/85926517.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":499427
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"17ae885e1258e9b54c8a03996195ff4c",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc0ac\uc9c1\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/23/85926523.geojson
+++ b/data/859/265/23/85926523.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1085059
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"265ebf8d50f02368cc9564f23c2da32e",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ub300\uc5f0\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/27/85926527.geojson
+++ b/data/859/265/27/85926527.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":224153
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7efb5e5a3b1b9dcdf0f0072ac450cf98",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581674,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc6a9\ud638\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/31/85926531.geojson
+++ b/data/859/265/31/85926531.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835198
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf7d9e3d32815354e0a6f425b42c3ef0",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc6b0\uc554\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/35/85926535.geojson
+++ b/data/859/265/35/85926535.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1002733
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"4ab63c5ad21ccfa184fd1bcb4d9b2ff0",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581674,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uad6c\ud3ec\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/41/85926541.geojson
+++ b/data/859/265/41/85926541.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":229869
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6dd9b050609ec4e7ef998a0a6c7e7553",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ub355\ucc9c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/45/85926545.geojson
+++ b/data/859/265/45/85926545.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":907706
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"edbad546ae995eac4c3f36b81604c79c",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581674,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ub9cc\ub355\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/49/85926549.geojson
+++ b/data/859/265/49/85926549.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835203
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ccd28982592dcc57dba39ce8649f3e3",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581676,
+    "wof:lastmodified":1582347123,
     "wof:name":"\uc911\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/53/85926553.geojson
+++ b/data/859/265/53/85926553.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835204
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2aefca85ed64e611a2637c584bafcc9",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc88c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/59/85926559.geojson
+++ b/data/859/265/59/85926559.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835206
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"624d8f0c714c78723d65edef2ce46b8d",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581674,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ubc18\uc1a1\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/67/85926567.geojson
+++ b/data/859/265/67/85926567.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1085060
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"13ca856d7f1be69c6ee20fbe486d20ec",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581674,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uc7a5\uc804\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/71/85926571.geojson
+++ b/data/859/265/71/85926571.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1186148
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f7e8b1963c97ba05530823e1e8ab9e4",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uad6c\uc11c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/81/85926581.geojson
+++ b/data/859/265/81/85926581.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835219
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"106201c28526ce241a28d036368e388d",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uac70\uc81c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/85/85926585.geojson
+++ b/data/859/265/85/85926585.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":242066
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3bf4e03b42c674c7a9a1d6e306031053",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ub0a8\ucc9c\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/89/85926589.geojson
+++ b/data/859/265/89/85926589.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":232371
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6bbc7c01f5d86a93187d66aa79e31cf",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581674,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uad11\uc548\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/95/85926595.geojson
+++ b/data/859/265/95/85926595.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1138131
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f96b3e3fdb7a5a918bc94dba298dddd1",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581673,
+    "wof:lastmodified":1582347122,
     "wof:name":"\uac10\uc804\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/265/99/85926599.geojson
+++ b/data/859/265/99/85926599.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":242050
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9890903b2ffbbe540d6930ae2fdbc858",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581675,
+    "wof:lastmodified":1582347122,
     "wof:name":"\ub3d9\uc778\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/03/85926603.geojson
+++ b/data/859/266/03/85926603.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835229
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"de24f223d0d089017c6dbbb2660daa73",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581640,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc131\ub0b4\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/07/85926607.geojson
+++ b/data/859/266/07/85926607.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835230
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"779a3fcc7d311fe04cebd57d4a81e1a3",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub0a8\uc0b0\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/13/85926613.geojson
+++ b/data/859/266/13/85926613.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1186117
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c76e1560b98257f65e383b3ceae84ba7",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub300\ubd09\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/17/85926617.geojson
+++ b/data/859/266/17/85926617.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":232372
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aff6e4d8845c466e3cea199a41c96220",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc2e0\uc554\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/21/85926621.geojson
+++ b/data/859/266/21/85926621.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":986419
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec1865d7620d2300e6e8134ed0bc95f1",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc2e0\ucc9c\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/25/85926625.geojson
+++ b/data/859/266/25/85926625.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":482074
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"858e070c4dc558b82bee3c89d917bb0c",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub0b4\ub2f9\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/31/85926631.geojson
+++ b/data/859/266/31/85926631.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":482077
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1584d2cd5465072e152b6407a4c82cc3",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub300\uba85\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/35/85926635.geojson
+++ b/data/859/266/35/85926635.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835241
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"711ec9f0de932112b1fe02b906de1860",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581640,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uce68\uc0b0\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/39/85926639.geojson
+++ b/data/859/266/39/85926639.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1328454
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"60682123a34ed8f1a1e1c4a997adfecf",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub178\uc6d0\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/43/85926643.geojson
+++ b/data/859/266/43/85926643.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835243
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a2e1fb2f7c7111681c3f7037422108a",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc0b0\uaca9\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/49/85926649.geojson
+++ b/data/859/266/49/85926649.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":482091
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d182498c8fc9c7a28b50953a5e74c1ec",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ubcf5\ud604\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/53/85926653.geojson
+++ b/data/859/266/53/85926653.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":482098
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"867514043f13faaa8029f5927389e609",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ud0dc\uc804\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/55/85926655.geojson
+++ b/data/859/266/55/85926655.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835248
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"389ad959b6f8e5a1218ffe84bfc5b8ac",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub9cc\ucd0c\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/59/85926659.geojson
+++ b/data/859/266/59/85926659.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835249
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5c8f5c91d47b36ba21a2a9ace2300fed",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581640,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc218\uc131\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/65/85926665.geojson
+++ b/data/859/266/65/85926665.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835250
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"92711191e9b6a878f8220a16ff6ca4b4",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ud669\uae08\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/73/85926673.geojson
+++ b/data/859/266/73/85926673.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1287164
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bb07fa7b2d1a9dd50cc2d7b791cbe2a9",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581641,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub450\ub958\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/77/85926677.geojson
+++ b/data/859/266/77/85926677.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1294631
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c3a3e98003883f8636896c165972a49d",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc6d4\uc131\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/83/85926683.geojson
+++ b/data/859/266/83/85926683.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835259
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"49f576bd682df0e7c4638e337c381af3",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc1a1\ud604\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/85/85926685.geojson
+++ b/data/859/266/85/85926685.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835261
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6eb08478346ccc837bd4347ff5371bc3",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc22d\uc758\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/89/85926689.geojson
+++ b/data/859/266/89/85926689.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835262
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d87e0a4c8a2ff8077299952ca1371a16",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581640,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc6a9\ud604\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/93/85926693.geojson
+++ b/data/859/266/93/85926693.geojson
@@ -78,6 +78,9 @@
         "wd:id":"Q2681343"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3fc086263282e81bf4de82929e67c677",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581640,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub3c4\ud654\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/266/97/85926697.geojson
+++ b/data/859/266/97/85926697.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835265
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d31ad5d1b6f51308a862b93c7c5bdbb1",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581642,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc8fc\uc548\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/03/85926703.geojson
+++ b/data/859/267/03/85926703.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835266
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"865726561edd5dc5ebf065d30d95817b",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581649,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc5f0\uc218\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/07/85926707.geojson
+++ b/data/859/267/07/85926707.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1294635
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7e2611e82c8d6309d481d0e25597e3e8",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581650,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ub3d9\ucd98\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/21/85926721.geojson
+++ b/data/859/267/21/85926721.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1294632
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a528bbe8efe1ca12aa6126ca9d8e0c9b",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581650,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uad6c\uc6d4\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/25/85926725.geojson
+++ b/data/859/267/25/85926725.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835269
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"99de07fd65e62557db79d53d4b6a3459",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581651,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uac04\uc11d\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/29/85926729.geojson
+++ b/data/859/267/29/85926729.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835271
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aba992f90f4d8cec857a85efa7b621af",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581650,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ubd80\ud3c9\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/33/85926733.geojson
+++ b/data/859/267/33/85926733.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1294637
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"29bef4e1611da22c16555c81a95f121e",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581650,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ubd80\uac1c\ub3d9",
     "wof:parent_id":102026355,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/39/85926739.geojson
+++ b/data/859/267/39/85926739.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835276
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"52c815b0e1a58c3f74b33e08c7aa9cf0",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581651,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc2ed\uc815\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/41/85926741.geojson
+++ b/data/859/267/41/85926741.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":992966
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"10136f6bbfbc4f047824652f22593a00",
     "wof:hierarchy":[
         {
@@ -91,7 +95,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581651,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uacc4\uc0b0\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/45/85926745.geojson
+++ b/data/859/267/45/85926745.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835280
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f1e8058a25597b07129a83d950ee7976",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581650,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uacc4\uc591\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/49/85926749.geojson
+++ b/data/859/267/49/85926749.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835281
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8761b2eb05ddd67682cc8e8b95be7d92",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581651,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uac00\uc815\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/59/85926759.geojson
+++ b/data/859/267/59/85926759.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":992968
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"358b78b314f891d2d00511c0ecf34f31",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581649,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uacc4\ub9bc\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/63/85926763.geojson
+++ b/data/859/267/63/85926763.geojson
@@ -70,6 +70,9 @@
         "gp:id":28835290
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f51253b6751c4c3f9b5f8d1757417ac8",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581651,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc0c1\ubb34\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/67/85926767.geojson
+++ b/data/859/267/67/85926767.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":992970
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"990a205116f780f6dff7cae67cc0ce4f",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581649,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ud654\uc815\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/73/85926773.geojson
+++ b/data/859/267/73/85926773.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":427104
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"75c606f33d457fbcea26965ebed53a6a",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581650,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc911\ud765\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/77/85926777.geojson
+++ b/data/859/267/77/85926777.geojson
@@ -70,6 +70,9 @@
         "gp:id":28835299
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3266ebc8fb8303852cb690fbaa842c85",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581651,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc6b4\uc554\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/81/85926781.geojson
+++ b/data/859/267/81/85926781.geojson
@@ -80,6 +80,10 @@
         "wk:page":"Cartsdyke railway station"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eedc36babae57e7545164a5a00c1115d",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581650,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc0bc\uc131\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/85/85926785.geojson
+++ b/data/859/267/85/85926785.geojson
@@ -67,6 +67,9 @@
         "gp:id":28835314
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"dfde05068eda370b245a5ce13f6c799e",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581651,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uac08\ub9c8\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/91/85926791.geojson
+++ b/data/859/267/91/85926791.geojson
@@ -80,6 +80,10 @@
         "wk:page":"Broome railway station"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"fa155accbb9155592308efacaedef74c",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581651,
+    "wof:lastmodified":1582347118,
     "wof:name":"\ub454\uc0b0\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/267/95/85926795.geojson
+++ b/data/859/267/95/85926795.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1294654
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3d2a83143613455aea739691006a39e6",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581649,
+    "wof:lastmodified":1582347118,
     "wof:name":"\uc628\ucc9c\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/01/85926801.geojson
+++ b/data/859/268/01/85926801.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":889541
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"740c6f290f107333bf7c47ad474ef40f",
     "wof:hierarchy":[
         {
@@ -86,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581638,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc2e0\uc815\ub3d9",
     "wof:parent_id":102026291,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/05/85926805.geojson
+++ b/data/859/268/05/85926805.geojson
@@ -81,6 +81,9 @@
         "wd:id":"Q11862764"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3af3bc16d4e893569b372f56080c454b",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581636,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ubb34\uac70\ub3d9",
     "wof:parent_id":102026291,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/11/85926811.geojson
+++ b/data/859/268/11/85926811.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1197781
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"49a0523a133ce0cbb1bf3d50db7473be",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581637,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud6a8\uc790\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/19/85926819.geojson
+++ b/data/859/268/19/85926819.geojson
@@ -74,6 +74,9 @@
         "wd:id":"Q2681442"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0a049a8d3d8df2201fe2c24bb3471bb5",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581637,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud3c9\ucc3d\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/33/85926833.geojson
+++ b/data/859/268/33/85926833.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":499428
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"872120147257afaed772fdc50851bbdb",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581636,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uac00\ud68c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/37/85926837.geojson
+++ b/data/859/268/37/85926837.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q2681135"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8e79b9b7ef4a71aba38159db28d3feb4",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581638,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc774\ud654\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/39/85926839.geojson
+++ b/data/859/268/39/85926839.geojson
@@ -100,6 +100,9 @@
         "wd:id":"Q2681350"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"918f42119829cc41231c69945400dd43",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581638,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ud61c\ud654\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/45/85926845.geojson
+++ b/data/859/268/45/85926845.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q493272"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6967998634119eb77dffe5d10aeacc73",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581637,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc18c\uacf5\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/49/85926849.geojson
+++ b/data/859/268/49/85926849.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1086482
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0d1d69e15e064ab4e560351c7198934e",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581640,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ud68c\ud604\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/57/85926857.geojson
+++ b/data/859/268/57/85926857.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":488690
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81db0fd6ba585a76d5ee25a39d81ba88",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581636,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc7a5\ucda9\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/63/85926863.geojson
+++ b/data/859/268/63/85926863.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1115425
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"362efa8dcd73b0f96f91f5e479308067",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581639,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uad11\ud76c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/67/85926867.geojson
+++ b/data/859/268/67/85926867.geojson
@@ -75,6 +75,9 @@
         "wd:id":"Q12610633"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"57984efd90fc11fb7b2fa89b95c6e0db",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581636,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc744\uc9c0\ub85c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/75/85926875.geojson
+++ b/data/859/268/75/85926875.geojson
@@ -68,6 +68,9 @@
         "qs_pg:id":900423
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1124313d22b9db25a51cd3d408fd6c7",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581637,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc911\ub9bc\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/81/85926881.geojson
+++ b/data/859/268/81/85926881.geojson
@@ -67,6 +67,9 @@
         "wd:id":"Q11288039"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9a9552ae9055ad4eb01bc367e27de03b",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581638,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ud6a8\ucc3d\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/85/85926885.geojson
+++ b/data/859/268/85/85926885.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":358778
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d971f982f825fd317f417049b285d065",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581639,
+    "wof:lastmodified":1582347117,
     "wof:name":"\uc6a9\ubb38\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/89/85926889.geojson
+++ b/data/859/268/89/85926889.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":358779
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a32fce0c7611c3826a8fdefcc6d9334e",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581637,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ubcf4\uad11\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/91/85926891.geojson
+++ b/data/859/268/91/85926891.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":890462
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a57011b1cb9c6b6c796a3ea7d2270007",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581638,
+    "wof:lastmodified":1582347117,
     "wof:name":"\ub3c4\uc120\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/268/95/85926895.geojson
+++ b/data/859/268/95/85926895.geojson
@@ -64,6 +64,9 @@
         "wd:id":"Q2681474"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8fdf4104e25f88f734b41f21948a257",
     "wof:hierarchy":[
         {
@@ -79,7 +82,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581636,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ub9c8\uc7a5\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/05/85926905.geojson
+++ b/data/859/269/05/85926905.geojson
@@ -70,6 +70,9 @@
         "wd:id":"Q2681195"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d3f240daf3bc628711e1cbf7247e4d22",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581656,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc751\ubd09\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/09/85926909.geojson
+++ b/data/859/269/09/85926909.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":424427
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"49ece2f5bd202092ec328726b0db5809",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581656,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc1a1\uc815\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/13/85926913.geojson
+++ b/data/859/269/13/85926913.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q2681191"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ed3675cabcd58fb173ceed31584cbcc",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581658,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc6a9\ub2f5\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/19/85926919.geojson
+++ b/data/859/269/19/85926919.geojson
@@ -73,6 +73,9 @@
         "wd:id":"Q2647381"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1810457fcee2ebba820084c04993cdfd",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581656,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ud654\uc591\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/23/85926923.geojson
+++ b/data/859/269/23/85926923.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q2647305"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"789ad1711be9d9907203555cd5bc558c",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581658,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ub2a5\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/27/85926927.geojson
+++ b/data/859/269/27/85926927.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":230195
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"afc09993ddb566c948e5a2f47f0ce6e7",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581656,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ud68c\uae30\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/31/85926931.geojson
+++ b/data/859/269/31/85926931.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1086484
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"31d5746855825241cd7ccbb870acb678",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581657,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ub3d9\uc18c\ubb38\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/37/85926937.geojson
+++ b/data/859/269/37/85926937.geojson
@@ -67,6 +67,9 @@
         "wd:id":"Q2681787"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b8499b429684576118eae4c3110cf27f",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581657,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ubcf4\ubb38\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/41/85926941.geojson
+++ b/data/859/269/41/85926941.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":427170
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b37bc76cd573b114b9f2684eb1428438",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581658,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc0c1\uc6d4\uace1\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/43/85926943.geojson
+++ b/data/859/269/43/85926943.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":260176
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a58dc2002aca8b1fe406d3af5cd1a366",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581656,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc911\uacc4\ubcf8\ub3d9",
     "wof:parent_id":102026525,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/47/85926947.geojson
+++ b/data/859/269/47/85926947.geojson
@@ -72,6 +72,9 @@
         "wd:id":"Q2648775"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dd8c6e27168aea0015e250694537e289",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581658,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ub179\ubc88\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/57/85926957.geojson
+++ b/data/859/269/57/85926957.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q2647458"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dc57bc315ff56da4f2b02c70a3f19121",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581656,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ub300\uc870\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/61/85926961.geojson
+++ b/data/859/269/61/85926961.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1086486
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6f807d91567489e410ea08138b8dfab",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581655,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc99d\uc0b0\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/79/85926979.geojson
+++ b/data/859/269/79/85926979.geojson
@@ -80,6 +80,9 @@
         "qs_pg:id":1086487
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b928dc25242b276ffff6f91941705ba5",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581657,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ucda9\uc815\ub85c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/81/85926981.geojson
+++ b/data/859/269/81/85926981.geojson
@@ -66,6 +66,9 @@
         "wd:id":"Q2681488"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5c7189d9696765ead1ed9c7d008c3c55",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581656,
+    "wof:lastmodified":1582347119,
     "wof:name":"\ucc9c\uc5f0\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/85/85926985.geojson
+++ b/data/859/269/85/85926985.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1086488
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5caefb265e461eab11217c35cf8b5715",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581658,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ub300\uc2e0\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/91/85926991.geojson
+++ b/data/859/269/91/85926991.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":899612
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c484c8805d9bb7ec327bf402276eb94b",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581657,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc2e0\uacf5\ub355\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/95/85926995.geojson
+++ b/data/859/269/95/85926995.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1086489
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b828b7689e30624ea014d38d1aad5ef7",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581655,
+    "wof:lastmodified":1582347119,
     "wof:name":"\uc6a9\uac15\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/269/99/85926999.geojson
+++ b/data/859/269/99/85926999.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1086490
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aa96c8436f1feab9386a5e7a89ec13d5",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581657,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ub178\uace0\uc0b0\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/03/85927003.geojson
+++ b/data/859/270/03/85927003.geojson
@@ -61,6 +61,9 @@
         "wd:id":"Q5072055"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3f2d3f9ad6128a62d70f37d46565df0e",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581658,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ucc3d\uc804\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/09/85927009.geojson
+++ b/data/859/270/09/85927009.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":1197898
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4bf1b5652fa2b585ffafefea78839fea",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581660,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc0c1\uc218\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/11/85927011.geojson
+++ b/data/859/270/11/85927011.geojson
@@ -71,6 +71,9 @@
         "wd:id":"Q2681353"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"09a908f832247c87786e2f5d0f9548bc",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581659,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc5f0\ub0a8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/19/85927019.geojson
+++ b/data/859/270/19/85927019.geojson
@@ -72,6 +72,9 @@
         "wd:id":"Q2649152"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e98194257806a6dac040f5e6b3c973a4",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581659,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc5fc\ucc3d\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/25/85927025.geojson
+++ b/data/859/270/25/85927025.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1294848
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"137d836274e3b3e80599c687369706ed",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581662,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ud654\uace1\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/33/85927033.geojson
+++ b/data/859/270/33/85927033.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q2648179"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ceac3ed347917750f13e4cafc4526f4a",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581659,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc2e0\ub3c4\ub9bc\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/37/85927037.geojson
+++ b/data/859/270/37/85927037.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1294849
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bdece66956ef078584c45042b146d179",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581660,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uad6c\ub85c\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/47/85927047.geojson
+++ b/data/859/270/47/85927047.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":230198
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"559c009934c2c50a16b6af2c112ab9ac",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581662,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uac00\uc0b0\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/51/85927051.geojson
+++ b/data/859/270/51/85927051.geojson
@@ -73,6 +73,9 @@
         "qs_pg:id":985746
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f8a3337f4fc9faa6a237b86c5e25362e",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581659,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc2dc\ud765\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/53/85927053.geojson
+++ b/data/859/270/53/85927053.geojson
@@ -75,6 +75,9 @@
         "qs_pg:id":424434
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2ee38ea944eea6849f60f3cce075da6e",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581660,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/57/85927057.geojson
+++ b/data/859/270/57/85927057.geojson
@@ -79,6 +79,9 @@
         "wd:id":"Q2647158"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"11e86ec16fcb32f596a134a5649c6bd6",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581658,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ub300\ubc29\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/63/85927063.geojson
+++ b/data/859/270/63/85927063.geojson
@@ -81,6 +81,9 @@
         "qs_pg:id":358823
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3937a350fdba11204398730a0021d5a6",
     "wof:hierarchy":[
         {
@@ -96,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581661,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ubd09\ucc9c\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/67/85927067.geojson
+++ b/data/859/270/67/85927067.geojson
@@ -65,6 +65,9 @@
         "wd:id":"Q2648251"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"69519d5661ef6edb574a376337039e28",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581659,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ub0a8\ud604\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/71/85927071.geojson
+++ b/data/859/270/71/85927071.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":11465
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1d395e5a03b6fe8a8a0d5a62a8309a1f",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581661,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc2e0\ub9bc\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/75/85927075.geojson
+++ b/data/859/270/75/85927075.geojson
@@ -69,6 +69,9 @@
         "wd:id":"Q2681390"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3101741f86c06f56b3d3bcce61eeab1b",
     "wof:hierarchy":[
         {
@@ -84,7 +87,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581659,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc7a0\uc6d0\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/270/81/85927081.geojson
+++ b/data/859/270/81/85927081.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1086493
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"687a79c5638acc75f0467e0c1162c80e",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581660,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ubc18\ud3ec\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/09/85927109.geojson
+++ b/data/859/271/09/85927109.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1086494
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"386c73995b6f60254834a316c69eb387",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581663,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ubc29\ubc30\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/15/85927115.geojson
+++ b/data/859/271/15/85927115.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1197896
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b18fb65450abab0cc42841e2285abb0c",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ub0b4\uace1\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/19/85927119.geojson
+++ b/data/859/271/19/85927119.geojson
@@ -74,6 +74,9 @@
         "wd:id":"Q2648190"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"df66ddaf8e1c3a25a316969e83f7006e",
     "wof:hierarchy":[
         {
@@ -89,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581663,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc138\uace1\ub3d9",
     "wof:parent_id":102026521,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/23/85927123.geojson
+++ b/data/859/271/23/85927123.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":1001196
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8b6db15f970362907089f68b69fa3d75",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581664,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc77c\uc6d0\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/27/85927127.geojson
+++ b/data/859/271/27/85927127.geojson
@@ -73,6 +73,9 @@
         "wd:id":"Q626439"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6eb0b4055b1dfaef661029a6ea7a5e1",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581662,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc624\ub95c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/33/85927133.geojson
+++ b/data/859/271/33/85927133.geojson
@@ -79,6 +79,9 @@
         "wd:id":"Q12607745"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6316369847a9bfa6f9370cc015939c96",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581662,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc624\uae08\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/37/85927137.geojson
+++ b/data/859/271/37/85927137.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q7451539"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2e74950543d5ba229ee7db82919a7e3d",
     "wof:hierarchy":[
         {
@@ -103,7 +106,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581663,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc11d\ucd0c\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/41/85927141.geojson
+++ b/data/859/271/41/85927141.geojson
@@ -71,6 +71,9 @@
         "qs_pg:id":1294857
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"91cfdc06356a864827c671246c6c211c",
     "wof:hierarchy":[
         {
@@ -86,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581664,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uac00\ub77d\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/45/85927145.geojson
+++ b/data/859/271/45/85927145.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1294858
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d02e176f5533e7127ac241ea4332f9fb",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581663,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc7a5\uc9c0\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/51/85927151.geojson
+++ b/data/859/271/51/85927151.geojson
@@ -78,6 +78,9 @@
         "qs_pg:id":230200
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d21e830a1be735a10cc9b337abea794",
     "wof:hierarchy":[
         {
@@ -93,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581662,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc7a0\uc2e4\ubcf8\ub3d9",
     "wof:parent_id":102026327,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/59/85927159.geojson
+++ b/data/859/271/59/85927159.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":230189
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74901af58c0ae608d54158223b1227ec",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581662,
+    "wof:lastmodified":1582347120,
     "wof:name":"\uc911\uc559\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/63/85927163.geojson
+++ b/data/859/271/63/85927163.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":1294859
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"06bda1eb7ad924fa30716c68f4972992",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581664,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ub300\uccad\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/65/85927165.geojson
+++ b/data/859/271/65/85927165.geojson
@@ -68,6 +68,9 @@
         "gp:id":28995079
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"006a9941500bb01b1033b4db99172a09",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581663,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ubd80\ud3c9\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/71/85927171.geojson
+++ b/data/859/271/71/85927171.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":427182
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"81ef9af196c532b711086ef960271552",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581665,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uad11\ubcf5\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/75/85927175.geojson
+++ b/data/859/271/75/85927175.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":985750
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"154fb63567e3e224a692fd17b80875bd",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581663,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ubd80\ubbfc\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/79/85927179.geojson
+++ b/data/859/271/79/85927179.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":358848
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9eb4b0d870ca51af1bf491969e2c353",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581664,
+    "wof:lastmodified":1582347121,
     "wof:name":"\ucd08\uc7a5\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/83/85927183.geojson
+++ b/data/859/271/83/85927183.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":230202
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1e9057f2f70ebf99efc4f1b4364a3d5f",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581664,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc554\ub0a8\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/89/85927189.geojson
+++ b/data/859/271/89/85927189.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":427185
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"af7397f3b095063ef7cff5218de1e817",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581662,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ub0a8\ud56d\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/93/85927193.geojson
+++ b/data/859/271/93/85927193.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":55613
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0ddd2002a3d81764b36b7979394f78e6",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581662,
+    "wof:lastmodified":1582347120,
     "wof:name":"\ucd08\uc74d\ub3d9",
     "wof:parent_id":102026581,
     "wof:placetype":"neighbourhood",

--- a/data/859/271/97/85927197.geojson
+++ b/data/859/271/97/85927197.geojson
@@ -68,6 +68,9 @@
         "gp:id":28995089
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b8048ea97ec9dd8cac55f06a232da1ce",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581663,
+    "wof:lastmodified":1582347121,
     "wof:name":"\uc218\ubbfc\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/01/85927201.geojson
+++ b/data/859/272/01/85927201.geojson
@@ -74,6 +74,10 @@
         "qs_pg:id":985751
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c9e973af81ae39ca8b4c3f5e8b7a64f9",
     "wof:hierarchy":[
         {
@@ -89,7 +93,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ubcf5\uc0b0\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/07/85927207.geojson
+++ b/data/859/272/07/85927207.geojson
@@ -69,6 +69,9 @@
         "qs_pg:id":11476
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2ec2ef8e76e79361b75653dcbf90022",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc6a9\ub2f9\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/11/85927211.geojson
+++ b/data/859/272/11/85927211.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":995510
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2de5450fa7148a52029fb992cbf107bc",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ud654\uba85\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/15/85927215.geojson
+++ b/data/859/272/15/85927215.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":1119017
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e199a1e2fdfd71bcb95588bbedc8cfff",
     "wof:hierarchy":[
         {
@@ -94,7 +98,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc6b0\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/19/85927219.geojson
+++ b/data/859/272/19/85927219.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":233561
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9c5d330ecad172564c09f7df442e37e6",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc1a1\uc815\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/25/85927225.geojson
+++ b/data/859/272/25/85927225.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":427183
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1dc057e00e6ab3fa5f1b85b49d915897",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581633,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uad6c\ud3c9\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/29/85927229.geojson
+++ b/data/859/272/29/85927229.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":427184
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f9367756b24d7bae4b8947a87d3af4d3",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uccad\ub8e1\ub178\ud3ec\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/43/85927243.geojson
+++ b/data/859/272/43/85927243.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":43649
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7e77e9ce5615d99c6936d66cb7f7631a",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc218\uc601\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/47/85927247.geojson
+++ b/data/859/272/47/85927247.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":1091459
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1549604673ebec629c14b9463901e7d",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581633,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ubbfc\ub77d\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/55/85927255.geojson
+++ b/data/859/272/55/85927255.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":1091461
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"90534a6409b2ac274ab95ac7a16cacde",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uad18\ubc95\ub3d9",
     "wof:parent_id":102026353,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/61/85927261.geojson
+++ b/data/859/272/61/85927261.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":775507
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3efee1149a7da3582c0bfe0f5c354073",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc9c0\uc800\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/65/85927265.geojson
+++ b/data/859/272/65/85927265.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":902710
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"60c1e91235507bff5a219836a6c5d96b",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ubc29\ucd0c\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/71/85927271.geojson
+++ b/data/859/272/71/85927271.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":775508
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"23f385af541fd5e58f3782fc686a6341",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581633,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc0c1\uc911\uc774\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/77/85927277.geojson
+++ b/data/859/272/77/85927277.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":55630
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"05bcc738096e3413705b6479847a11a1",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc774\ucc9c\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/81/85927281.geojson
+++ b/data/859/272/81/85927281.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1182441
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"74833ee9dd05e7a39c7e2c8da1668245",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581632,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uace0\uc131\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/85/85927285.geojson
+++ b/data/859/272/85/85927285.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":231109
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3cd1c98ae77862ec93d0da64e372abcd",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581633,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uce60\uc131\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/89/85927289.geojson
+++ b/data/859/272/89/85927289.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":1294896
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ced3892d35877745e29f31c22cc9e767",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uac80\ub2e8\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/272/95/85927295.geojson
+++ b/data/859/272/95/85927295.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":775509
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"779658bf90621b07b32881d774200fb3",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uad00\uc74c\ub3d9",
     "wof:parent_id":102026315,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/03/85927303.geojson
+++ b/data/859/273/03/85927303.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1182442
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a6e301bd77bc9645781c22db99d8f795",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581629,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ub450\uc0b0\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/07/85927307.geojson
+++ b/data/859/273/07/85927307.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1104006
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"d8fabe0c0ac0608ba357b0f378760a3b",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581630,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc7a5\uae30\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/13/85927313.geojson
+++ b/data/859/273/13/85927313.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":962020
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c888a3cb220f590997755faedf919fc9",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc774\uace1\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/17/85927317.geojson
+++ b/data/859/273/17/85927317.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":775510
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"990a4b1ea072252ecaaa6c51c2de5fa7",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581629,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc9c4\ucc9c\ub3d9",
     "wof:parent_id":102026537,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/25/85927325.geojson
+++ b/data/859/273/25/85927325.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":213948
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"154f8b4a14df8114c74a6df67fcf515f",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc2e0\ud3ec\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/31/85927331.geojson
+++ b/data/859/273/31/85927331.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1197940
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"93374bcc7f4b97217d090f11f34df01a",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581630,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc2e0\ud765\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/33/85927333.geojson
+++ b/data/859/273/33/85927333.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1318340
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1f2bae71f71c5905a40e056a065be833",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581629,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ub3d9\uc778\ucc9c\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/37/85927337.geojson
+++ b/data/859/273/37/85927337.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":427195
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7c8588749ab00b38d54dc50c6967c2e6",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581630,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ubd81\uc131\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/43/85927343.geojson
+++ b/data/859/273/43/85927343.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":427198
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e40e655d50d9e5238afd9599d83c1ae7",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581630,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc1a1\uc6d4\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/57/85927357.geojson
+++ b/data/859/273/57/85927357.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":204134
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0fe9ff5c5af507ac73e65a5e1cf17d88",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581629,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ub9cc\uc11d\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/61/85927361.geojson
+++ b/data/859/273/61/85927361.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":239368
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f1a52f79294deeb106bad532f29bb8fe",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581628,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ud654\uc218\ud654\ud3c9\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/63/85927363.geojson
+++ b/data/859/273/63/85927363.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":241688
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"989f0b0186954f0ebb62eb8ea3f8e3c6",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581630,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ud654\uc218\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/67/85927367.geojson
+++ b/data/859/273/67/85927367.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":237082
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"1bb0fee1e811d520a236c95cdd1add63",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581629,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uad00\uad50\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/71/85927371.geojson
+++ b/data/859/273/71/85927371.geojson
@@ -79,6 +79,9 @@
         "qs_pg:id":237083
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"be085605fdf8b5c03de9875b749b1dc2",
     "wof:hierarchy":[
         {
@@ -94,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ubb38\ud559\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/75/85927375.geojson
+++ b/data/859/273/75/85927375.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":237084
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"62a066a879e43a229bc2219532b33f3d",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581629,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc625\ub828\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/79/85927379.geojson
+++ b/data/859/273/79/85927379.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":358867
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"91a18aa2c6ca7eacfa3b382bf9a8a65e",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581630,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc120\ud559\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/85/85927385.geojson
+++ b/data/859/273/85/85927385.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":32903
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8cf64db711ec57a56b8085d4f4800c51",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581631,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc7a5\uc218\uc11c\ucc3d\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/87/85927387.geojson
+++ b/data/859/273/87/85927387.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1154982
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e004990847a5b0060972d548c4e97f27",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581629,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ub17c\ud604\uace0\uc794\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/91/85927391.geojson
+++ b/data/859/273/91/85927391.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1059686
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"72eee67e7c2450092f0a101c6105d89f",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581630,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc0bc\uc0b0\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/95/85927395.geojson
+++ b/data/859/273/95/85927395.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1154979
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3ca33754d36d7619f2e69be4b8ea84e9",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581629,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uac80\uc554\uacbd\uc11c\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/99/85927399.geojson
+++ b/data/859/273/99/85927399.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1197947
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35e99c466ab2463749c1197889700089",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581630,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc5f0\ud76c\ub3d9",
     "wof:parent_id":102026447,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/05/85927405.geojson
+++ b/data/859/274/05/85927405.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":11491
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd5894a342124808602436f6f4d285ef",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581626,
+    "wof:lastmodified":1582347114,
     "wof:name":"\ucda9\uc7a5\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/09/85927409.geojson
+++ b/data/859/274/09/85927409.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":900425
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf30f949d67b12aadec49ae839cbe368",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uad11\ucc9c\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/13/85927413.geojson
+++ b/data/859/274/13/85927413.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1154976
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"70be15f19abf71e12d70ee7d4c44346e",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581628,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc720\ub355\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/21/85927421.geojson
+++ b/data/859/274/21/85927421.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":358883
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0179297ce64af1df8db7c984f42f880f",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc2e0\uc548\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/25/85927425.geojson
+++ b/data/859/274/25/85927425.geojson
@@ -82,6 +82,10 @@
         "qs_pg:id":238702
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7d10b4e87c74d0bc17148414f26d9f60",
     "wof:hierarchy":[
         {
@@ -105,7 +109,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581628,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uc6a9\ubd09\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/33/85927433.geojson
+++ b/data/859/274/33/85927433.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1182453
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"917f765553c5b867570e2c7f379d14e5",
     "wof:hierarchy":[
         {
@@ -99,7 +103,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581626,
+    "wof:lastmodified":1582347114,
     "wof:name":"\ube44\uc544\ub3d9",
     "wof:parent_id":102026391,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/39/85927439.geojson
+++ b/data/859/274/39/85927439.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1182454
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f69b928fdcf76c70967620bac3f05bb",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc6a9\uc6b4\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/43/85927443.geojson
+++ b/data/859/274/43/85927443.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1182455
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"dad7ba5401856fc5cca87f99e51f2e7f",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc18c\uc81c\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/45/85927445.geojson
+++ b/data/859/274/45/85927445.geojson
@@ -73,6 +73,10 @@
         "qs_pg:id":1294917
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a85a3be593066a520a6b96dad576d4a6",
     "wof:hierarchy":[
         {
@@ -88,7 +92,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc740\ud589\uc120\ud654\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/49/85927449.geojson
+++ b/data/859/274/49/85927449.geojson
@@ -80,6 +80,10 @@
         "qs_pg:id":1182452
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a35b48f81e5209d13336c37ddab2ff3",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581628,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ub300\ud765\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/53/85927453.geojson
+++ b/data/859/274/53/85927453.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1198037
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"eb4ef4adc3d21e09d2ed4601a79fa108",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc624\ub958\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/59/85927459.geojson
+++ b/data/859/274/59/85927459.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":427205
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"f2f82dee48112cd9cfd1059e59433129",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581626,
+    "wof:lastmodified":1582347114,
     "wof:name":"\ubcf5\uc218\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/63/85927463.geojson
+++ b/data/859/274/63/85927463.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":134059
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c86dc7f11fd41717dfc444a1740d6a5d",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc6a9\ubb38\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/67/85927467.geojson
+++ b/data/859/274/67/85927467.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1104014
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2948939bd1299e5bfd8a35ad1ecf5411",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581626,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uad34\uc815\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/71/85927471.geojson
+++ b/data/859/274/71/85927471.geojson
@@ -114,6 +114,10 @@
         "qs_pg:id":1198017
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1b8b32113d212a02c39cae746c8bf19",
     "wof:hierarchy":[
         {
@@ -129,7 +133,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581628,
+    "wof:lastmodified":1582347115,
     "wof:name":"\uac00\uc218\uc6d0\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/77/85927477.geojson
+++ b/data/859/274/77/85927477.geojson
@@ -77,6 +77,10 @@
         "qs_pg:id":1198078
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9399b1a5c8bf9ec0685a812e881606c9",
     "wof:hierarchy":[
         {
@@ -92,7 +96,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581628,
+    "wof:lastmodified":1582347115,
     "wof:name":"\ub9cc\ub144\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/83/85927483.geojson
+++ b/data/859/274/83/85927483.geojson
@@ -78,6 +78,10 @@
         "wk:page":"West Runton railway station"
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca07568948115292f8fde8060fd2c909",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581628,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc2e0\uc131\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/87/85927487.geojson
+++ b/data/859/274/87/85927487.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":427210
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"682464fedd860b9b041ebbe5caef599d",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc804\ubbfc\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/274/97/85927497.geojson
+++ b/data/859/274/97/85927497.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":134060
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7f69acb5d23c6aece6c265939eff782d",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581627,
+    "wof:lastmodified":1582347114,
     "wof:name":"\uc624\uc815\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/275/01/85927501.geojson
+++ b/data/859/275/01/85927501.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":1318782
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6fe20d616aa27e8f70cb4fd034308ae1",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc911\ub9ac\ub3d9",
     "wof:parent_id":102026311,
     "wof:placetype":"neighbourhood",

--- a/data/859/275/05/85927505.geojson
+++ b/data/859/275/05/85927505.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":233562
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"c72af321cb132929085cede20626f66c",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581633,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc625\uad50\ub3d9",
     "wof:parent_id":102026291,
     "wof:placetype":"neighbourhood",

--- a/data/859/275/11/85927511.geojson
+++ b/data/859/275/11/85927511.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":1119018
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"4882bb8b374bc210eba0ed01a5d7ea10",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581633,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc131\ub0a8\ub3d9",
     "wof:parent_id":102026291,
     "wof:placetype":"neighbourhood",

--- a/data/859/275/15/85927515.geojson
+++ b/data/859/275/15/85927515.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":911803
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c1352e24bc9a690181830d56941397e4",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ud0dc\ud654\ub3d9",
     "wof:parent_id":102026291,
     "wof:placetype":"neighbourhood",

--- a/data/859/275/19/85927519.geojson
+++ b/data/859/275/19/85927519.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":911804
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"611aaee33da97fc363150f494e398637",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ub2e4\uc6b4\ub3d9",
     "wof:parent_id":102026291,
     "wof:placetype":"neighbourhood",

--- a/data/859/275/23/85927523.geojson
+++ b/data/859/275/23/85927523.geojson
@@ -78,6 +78,10 @@
         "qs_pg:id":911805
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ca9418f6d4030455081b9a934ad94575",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581634,
+    "wof:lastmodified":1582347116,
     "wof:name":"\ub2ec\ub3d9",
     "wof:parent_id":102026291,
     "wof:placetype":"neighbourhood",

--- a/data/859/275/29/85927529.geojson
+++ b/data/859/275/29/85927529.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1164188
     },
     "wof:country":"KO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"527b4cff4043b4bc2e2fcf6181b1fb19",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566581633,
+    "wof:lastmodified":1582347116,
     "wof:name":"\uc0bc\uc0b0\ub3d9",
     "wof:parent_id":102026291,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.